### PR TITLE
Add support for `if-expressions`.

### DIFF
--- a/BettyLang.Core/AST/Expressions/IfExpression.cs
+++ b/BettyLang.Core/AST/Expressions/IfExpression.cs
@@ -1,0 +1,24 @@
+﻿using BettyLang.Core.Interpreter;
+
+namespace BettyLang.Core.AST
+{
+    public class IfExpression : Expression
+    {
+        public Expression Condition { get; }
+        public Expression ThenExpression { get; }
+        public List<(Expression Condition, Expression Expression)> ElseIfExpressions { get; }
+        public Expression ElseExpression { get; }
+
+        public IfExpression(Expression condition, Expression thenExpression,
+            List<(Expression Condition, Expression Expression)> elseIfExpressions,
+            Expression elseExpression)
+        {
+            Condition = condition;
+            ThenExpression = thenExpression;
+            ElseIfExpressions = elseIfExpressions ?? [];
+            ElseExpression = elseExpression;
+        }
+
+        public override Value Accept(IExpressionVisitor visitor) => visitor.Visit(this);
+    }
+}

--- a/BettyLang.Core/AST/IExpressionVisitor.cs
+++ b/BettyLang.Core/AST/IExpressionVisitor.cs
@@ -18,5 +18,6 @@ namespace BettyLang.Core.AST
         Value Visit(IndexerExpression node);
         Value Visit(ListLiteral node);
         Value Visit(FunctionExpression node);
+        Value Visit(IfExpression node);
     }
 }

--- a/BettyLang.Core/Interpreter/Interpreter.cs
+++ b/BettyLang.Core/Interpreter/Interpreter.cs
@@ -37,6 +37,28 @@ namespace BettyLang.Core.Interpreter
             throw new Exception("No main function found.");
         }
 
+        public Value Visit(IfExpression node)
+        {
+            var conditionResult = node.Condition.Accept(this).AsBoolean();
+
+            if (conditionResult)
+            {
+                return node.ThenExpression.Accept(this);
+            }
+            else
+            {
+                foreach (var (Condition, Expression) in node.ElseIfExpressions)
+                {
+                    if (Condition.Accept(this).AsBoolean())
+                    {
+                        return Expression.Accept(this);
+                    }
+                }
+                
+                return node.ElseExpression.Accept(this);
+            }
+        }
+
         public Value Visit(ListLiteral node)
         {
             var elements = node.Elements.Select(e => e.Accept(this)).ToList();

--- a/BettyLang.Core/Lexer.cs
+++ b/BettyLang.Core/Lexer.cs
@@ -16,6 +16,7 @@
             ["true"] = TokenType.TrueKeyword,
             ["false"] = TokenType.FalseKeyword,
             ["if"] = TokenType.If,
+            ["then"] = TokenType.Then,
             ["elif"] = TokenType.Elif,
             ["else"] = TokenType.Else,
             ["for"] = TokenType.For,

--- a/BettyLang.Core/Parser.cs
+++ b/BettyLang.Core/Parser.cs
@@ -63,7 +63,6 @@ namespace BettyLang.Core
             };
         }
 
-
         private void Consume(TokenType tokenType)
         {
             if (_currentToken.Type == tokenType)
@@ -269,6 +268,11 @@ namespace BettyLang.Core
                     expr = ParseFunctionExpression();
                     break;
 
+                // If expression
+                case TokenType.If:
+                    expr = ParseIfExpression();
+                    break;
+
                 default:
                     throw new Exception($"Unexpected token: {token.Type}");
             }
@@ -323,6 +327,29 @@ namespace BettyLang.Core
             }
 
             return results;
+        }
+
+        private IfExpression ParseIfExpression()
+        {
+            Consume(TokenType.If);
+            var condition = ParseExpression();
+            Consume(TokenType.Then);
+            var thenExpression = ParseExpression();
+
+            var elseIfExpressions = new List<(Expression Condition, Expression Expression)>();
+            while (_currentToken.Type == TokenType.Elif)
+            {
+                Consume(TokenType.Elif);
+                var elseIfCondition = ParseExpression();
+                Consume(TokenType.Then);
+                var elseIfExpression = ParseExpression();
+                elseIfExpressions.Add((elseIfCondition, elseIfExpression));
+            }
+            
+            Consume(TokenType.Else);
+            var elseExpression = ParseExpression();
+
+            return new IfExpression(condition, thenExpression, elseIfExpressions, elseExpression);
         }
 
         private IfStatement ParseIfStatement()

--- a/BettyLang.Core/Token.cs
+++ b/BettyLang.Core/Token.cs
@@ -17,7 +17,7 @@
 
         // Keywords/identifiers
         Func, Global, TrueKeyword, FalseKeyword, Identifier,
-        If, Elif, Else, For, ForEach, In, While, Do, Break, Continue, Return,
+        If, Then, Elif, Else, For, ForEach, In, While, Do, Break, Continue, Return,
 
         // Assignment operators
         Equal, Increment, Decrement, PlusEqual, MinusEqual,

--- a/BettyLang.Tests/InterpreterTests/ConditionalStatementTests.cs
+++ b/BettyLang.Tests/InterpreterTests/ConditionalStatementTests.cs
@@ -546,5 +546,78 @@
             var result = interpreter.Interpret();
             Assert.Equal(5.0, result.AsNumber());
         }
+
+        [Fact]
+        public void IfExpression_ExecutesCorrectBranch()
+        {
+            var code = @"
+        x = if 1 == 1 then 2 else 6;
+        return x;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(2.0, result.AsNumber());
+        }
+
+        [Fact]
+        public void ElifExpression_ExecutesCorrectBranch()
+        {
+            var code = @"
+        x = if 1 == 2 then 2 elif 2 == 2 then 5 else 6;
+        return x;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(5.0, result.AsNumber());
+        }
+
+        [Fact]
+        public void ElseExpression_ExecutesCorrectBranch()
+        {
+            var code = @"
+        x = if 1 == 2 then 2 elif 2 == 3 then 5 else 6;
+        return x;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(6.0, result.AsNumber());
+        }
+
+        [Fact]
+        public void NestedIfElifElse_ExecutesCorrectBranch()
+        {
+            var code = @"
+        x = if 1 == 2 then 2 elif 2 == 2 then if 3 == 3 then 8 else 7 else 6;
+        return x;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(8.0, result.AsNumber());
+        }
+
+        [Fact]
+        public void MultipleElifConditions_ExecutesCorrectBranch()
+        {
+            var code = @"
+        x = if 1 == 2 then 2 elif 2 == 3 then 5 elif 4 == 4 then 7 else 6;
+        return x;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(7.0, result.AsNumber());
+        }
+
+        [Fact]
+        public void NoConditionTrue_ExecutesElseBranch()
+        {
+            var code = @"
+        x = if 1 == 3 then 2 elif 2 == 5 then 5 else 9;
+        return x;
+    ";
+            var interpreter = SetupInterpreter(code);
+            var result = interpreter.Interpret();
+            Assert.Equal(9.0, result.AsNumber());
+        }
+
     }
 }


### PR DESCRIPTION
- Implement if-expressions to further enable functional programming practices in Betty.
- Add new language keyword `then` to be used in `if-expressions`.
- Update `TokenType` to include the new keyword.
- Update lexer to correctly scan the new keyword.
- Add `IfExpression` node to the AST.
- Update parser to correctly parse `if-expressions`.
- Write extensive unit tests for this new functionality.